### PR TITLE
Fix defines: WITH_X2GO_AWARENESS, WITH_OGON_AWARENESS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,8 +61,7 @@ dnl enable/disable awarenesses
 AC_ARG_ENABLE([x2go],
               [AS_HELP_STRING([--enable-x2go],
                               [enable awareness of X2Go sessions])],
-              [enable_x2go=yes],
-              [enable_x2go=no])
+              [enable_x2go=yes])
 if test "x$enable_x2go" != "x"; then
     AC_DEFINE([WITH_X2GO_AWARENESS],,[Build with X2Go awareness])
 fi
@@ -70,8 +69,7 @@ fi
 AC_ARG_ENABLE([ogon],
               [AS_HELP_STRING([--enable-ogon],
                               [enable awareness of Ogon sessions])],
-              [enable_ogon=yes],
-              [enable_ogon=no])
+              [enable_ogon=yes])
 if test "x$enable_ogon" != "x"; then
     AC_DEFINE([WITH_OGON_AWARENESS],,[Build with Ogon awareness])
 fi


### PR DESCRIPTION
They are always enabled:
- Edit debian/rules
- Remove --enable-x2go or --enable-ogon line
- Run $ debuild -b -uc -us
- Check config.log e.g.

$ cat config.log | grep WITH_X2GO_AWARENESS
| #define WITH_X2GO_AWARENESS /**/
| #define WITH_X2GO_AWARENESS /**/

$ cat config.log | grep WITH_OGON_AWARENESS
| #define WITH_OGON_AWARENESS /**/
| #define WITH_OGON_AWARENESS /**/

$ cat debian/rules
..
override_dh_auto_configure:
	dh_auto_configure $(DHFLAGS) --		\
	        --disable-silent-rules		\
	        --enable-x2go			\
	        $(NULL)