### PR TITLE
Implement generic protocol support.

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,5 +1,6 @@
 src/rda.c
 src/rda_x2go.c
 src/rda_ogon.c
+src/rda_protocol.c
 src/rda_util.c
 util/rdacheck.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,5 @@
 src/rda.c
 src/rda_x2go.c
 src/rda_ogon.c
+src/rda_util.c
 util/rdacheck.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ librdaincludedir = $(includedir)/rda
 librdainclude_HEADERS =			\
 	rda_supported_technologies.h	\
 	rda_ogon.h			\
+	rda_protocol.h			\
 	rda_util.h			\
 	rda_x2go.h			\
 	rda.h				\
@@ -30,6 +31,7 @@ librda_la_SOURCES =			\
 	rda.c				\
 	rda_x2go.c			\
 	rda_ogon.c			\
+	rda_protocol.c			\
 	rda_util.c			\
 	$(NULL)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ librdaincludedir = $(includedir)/rda
 librdainclude_HEADERS =			\
 	rda_supported_technologies.h	\
 	rda_ogon.h			\
+	rda_util.h			\
 	rda_x2go.h			\
 	rda.h				\
 	$(NULL)
@@ -29,6 +30,7 @@ librda_la_SOURCES =			\
 	rda.c				\
 	rda_x2go.c			\
 	rda_ogon.c			\
+	rda_util.c			\
 	$(NULL)
 
 librda_la_CFLAGS =			\

--- a/src/rda.c
+++ b/src/rda.c
@@ -27,6 +27,7 @@
 #include <rda.h>
 #include <rda_ogon.h>
 #include <rda_x2go.h>
+#include <rda_protocol.h>
 
 guint
 remote_technology = REMOTE_TECHNOLOGY_UNCHECKED;
@@ -46,6 +47,7 @@ rda_session_is_local(void)
 	if (g_getenv("XDG_SEAT"))
 	{
 		remote_technology = REMOTE_TECHNOLOGY_NONE;
+		rda_protocol = RDA_PROTOCOL_NONE;
 		return TRUE;
 	}
 
@@ -57,7 +59,7 @@ rda_session_is_remote (void)
 {
 
 	if (rda_session_is_local())
-		remote_technology = REMOTE_TECHNOLOGY_NONE;
+		return FALSE;
 #ifdef WITH_REMOTE_AWARENESS_X2GO
 	else if (rda_session_is_x2go())
 		return TRUE;

--- a/src/rda_ogon.c
+++ b/src/rda_ogon.c
@@ -25,8 +25,16 @@
 #include <glib/gi18n.h>
 
 #include <rda.h>
+#include <rda_ogon.h>
+#include <rda_protocol.h>
+#include <rda_util.h>
 
 #ifdef WITH_REMOTE_AWARENESS_OGON
+
+const rda_protocol_t
+rda_supported_protocols_ogon[] = { RDA_PROTOCOL_RDP };
+const gsize
+rda_supported_protocols_ogon_len = static_arr_size(rda_supported_protocols_ogon);
 
 gboolean
 rda_session_is_ogon (void)
@@ -37,6 +45,7 @@ rda_session_is_ogon (void)
 	if (g_getenv("OGON_SID"))
 	{
 		remote_technology = REMOTE_TECHNOLOGY_OGON;
+		rda_protocol = RDA_PROTOCOL_RDP;
 		return TRUE;
 	}
 

--- a/src/rda_ogon.h
+++ b/src/rda_ogon.h
@@ -27,8 +27,14 @@
 #include <glib.h>
 
 #include <rda.h>
+#include <rda_protocol.h>
 
 #ifdef WITH_REMOTE_AWARENESS_OGON
+
+extern const rda_protocol_t
+rda_supported_protocols_ogon[];
+extern const gsize
+rda_supported_protocols_ogon_len;
 
 gboolean
 rda_session_is_ogon (void);

--- a/src/rda_protocol.c
+++ b/src/rda_protocol.c
@@ -1,0 +1,203 @@
+/* -*- Mode: C; c-set-style: linux indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+
+/* rda_protocol.c - Generic protocol support for remote sessions
+
+   Copyright (C) 2023 Mihai Moldovan <ionic@ionic.de>
+   All rights reserved.
+
+   The RDA Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   The RDA Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with the Mate Library; see the file COPYING.LIB.  If not,
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+ */
+
+#include <glib.h>
+#include <glib/gi18n.h>
+
+#include <rda_protocol.h>
+#include <rda.h>
+#include <rda_x2go.h>
+#include <rda_ogon.h>
+
+static guint supported_protos[RDA_PROTOCOL_MAX] = { };
+static gboolean supported_protos_init = FALSE;
+
+rda_protocol_t
+rda_protocol = RDA_PROTOCOL_MAX;
+
+guint
+rda_get_protocol(void)
+{
+	if (RDA_PROTOCOL_MAX == rda_protocol)
+	{
+		rda_init();
+	}
+
+	return rda_protocol;
+}
+
+static const gchar*
+rda_protocol_name_nx(void)
+{
+	return _("NX");
+}
+
+static const gchar*
+rda_protocol_name_kdrive(void)
+{
+	return _("KDrive");
+}
+
+static const gchar*
+rda_protocol_name_rdp(void)
+{
+	return _("RDP");
+}
+
+static const gchar*
+rda_protocol_name_vnc(void)
+{
+	return _("VNC");
+}
+
+gchar*
+rda_get_protocol_name (void)
+{
+	if (RDA_PROTOCOL_MAX == rda_protocol)
+		rda_init();
+
+	gchar* rda_protocol_name;
+
+	switch(rda_protocol) {
+
+		case RDA_PROTOCOL_NONE:
+			rda_protocol_name = g_strdup(_("local"));
+			break;
+
+		case RDA_PROTOCOL_NX:
+			rda_protocol_name = g_strdup(rda_protocol_name_nx());
+			break;
+
+		case RDA_PROTOCOL_KDRIVE:
+			rda_protocol_name = g_strdup(rda_protocol_name_kdrive());
+			break;
+
+		case RDA_PROTOCOL_RDP:
+			rda_protocol_name = g_strdup(rda_protocol_name_rdp());
+			break;
+
+		case RDA_PROTOCOL_VNC:
+			rda_protocol_name = g_strdup(rda_protocol_name_vnc());
+			break;
+
+		case RDA_PROTOCOL_UNKNOWN:
+			rda_protocol_name = g_strdup(_("unknown"));
+
+		default:
+			rda_protocol_name = g_strdup("");
+
+	}
+
+	/*
+	 * Moving g_strdup() down here might sound tempting, but don't do
+	 * that.
+	 *
+	 * Even though, at the time of writing this comment, all functions
+	 * used in here actually return a string literal (and as such, a
+	 * "const gchar*"), this may not be true forever and it's too easy
+	 * to leak memory by copying an already heap-allocated string.
+	 */
+	return rda_protocol_name;
+}
+
+static void
+init_supported_protos(void)
+{
+	if (!(supported_protos_init))
+	{
+		/* Initialize the list. */
+#define merge_arr(name) \
+	do \
+	{ \
+		for (gsize i = 0; i < rda_supported_protocols_ ## name ## _len; ++i) \
+		{ \
+			supported_protos[rda_supported_protocols_ ## name [i]] = TRUE; \
+		} \
+	} \
+	while (0)
+
+#ifdef WITH_REMOTE_AWARENESS_X2GO
+		merge_arr(x2go);
+#endif
+
+#ifdef WITH_REMOTE_AWARENESS_OGON
+		merge_arr(ogon);
+#endif
+
+#undef merge_arr
+		supported_protos_init = TRUE;
+	}
+}
+
+GList*
+rda_supported_protocols(void)
+{
+	GList *proto_list = NULL;
+
+	init_supported_protos();
+
+	for (gsize i = 0; i < RDA_PROTOCOL_MAX; ++i)
+	{
+		if (supported_protos[i])
+		{
+			proto_list = g_list_append (proto_list, GUINT_TO_POINTER(i));
+		}
+	}
+
+	return proto_list;
+}
+
+GList*
+rda_supported_protocols_by_name(void)
+{
+	GList *proto_list_by_name = NULL;
+
+	init_supported_protos();
+
+	for (gsize i = 0; i < RDA_PROTOCOL_MAX; ++i)
+	{
+		if (supported_protos[i])
+		{
+			switch (i)
+			{
+				case RDA_PROTOCOL_NX:
+					proto_list_by_name = g_list_append (proto_list_by_name, g_strdup(rda_protocol_name_nx()));
+					break;
+
+				case RDA_PROTOCOL_KDRIVE:
+					proto_list_by_name = g_list_append (proto_list_by_name, g_strdup(rda_protocol_name_kdrive()));
+					break;
+
+				case RDA_PROTOCOL_RDP:
+					proto_list_by_name = g_list_append (proto_list_by_name, g_strdup(rda_protocol_name_rdp()));
+					break;
+
+				case RDA_PROTOCOL_VNC:
+					proto_list_by_name = g_list_append (proto_list_by_name, g_strdup(rda_protocol_name_vnc()));
+					break;
+			}
+		}
+	}
+
+	return proto_list_by_name;
+}

--- a/src/rda_protocol.h
+++ b/src/rda_protocol.h
@@ -1,0 +1,58 @@
+/* -*- Mode: C; c-set-style: linux indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+
+/* rda_protocol.h - Generic protocol support for remote sessions
+
+   Copyright (C) 2023 Mihai Moldovan <ionic@ionic.de>
+   All rights reserved.
+
+   The RDA Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   The RDA Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with the Mate Library; see the file COPYING.LIB.  If not,
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA  02110-1301, USA.
+ */
+
+#ifndef RDA_PROTOCOL_H
+#define RDA_PROTOCOL_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+typedef enum {
+	RDA_PROTOCOL_UNKNOWN = 0,
+	RDA_PROTOCOL_NONE,
+	RDA_PROTOCOL_VNC,
+	RDA_PROTOCOL_RDP,
+	RDA_PROTOCOL_NX,
+	RDA_PROTOCOL_KDRIVE,
+	RDA_PROTOCOL_MAX,
+} rda_protocol_t;
+
+extern rda_protocol_t
+rda_protocol;
+
+guint
+rda_get_protocol(void);
+
+gchar*
+rda_get_protocol_name(void);
+
+GList*
+rda_supported_protocols(void);
+
+GList*
+rda_supported_protocols_by_name(void);
+
+G_END_DECLS
+
+#endif /* RDA_PROTOCOL_H */

--- a/src/rda_util.c
+++ b/src/rda_util.c
@@ -1,0 +1,27 @@
+/* -*- Mode: C; c-set-style: linux indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+
+/* rda_util.c - Miscellaneous helpers
+
+   Copyright (C) 2023 Mihai Moldovan <ionic@ionic.de>
+   All rights reserved.
+
+   The RDA Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   The RDA Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with the Mate Library; see the file COPYING.LIB.  If not,
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+ */
+
+#include <glib.h>
+#include <glib/gi18n.h>
+
+#include <rda_util.h>

--- a/src/rda_util.h
+++ b/src/rda_util.h
@@ -1,0 +1,35 @@
+/* -*- Mode: C; c-set-style: linux indent-tabs-mode: t; c-basic-offset: 8; tab-width: 8 -*- */
+
+/* rda_util.h - Miscellaneous helpers
+
+   Copyright (C) 2023 Mihai Moldovan <ionic@ionic.de>
+   All rights reserved.
+
+   The RDA Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Library General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   The RDA Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Library General Public License for more details.
+
+   You should have received a copy of the GNU Library General Public
+   License along with the Mate Library; see the file COPYING.LIB.  If not,
+   write to the Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+   Boston, MA 02110-1301, USA.
+ */
+
+#ifndef RDA_UTIL_H
+#define RDA_UTIL_H
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+#define static_arr_size(arr) (sizeof(arr) / sizeof(*arr))
+
+G_END_DECLS
+
+#endif /* RDA_UTIL_H */

--- a/src/rda_x2go.h
+++ b/src/rda_x2go.h
@@ -27,8 +27,14 @@
 #include <glib.h>
 
 #include <rda.h>
+#include <rda_protocol.h>
 
 #ifdef WITH_REMOTE_AWARENESS_X2GO
+
+extern const rda_protocol_t
+rda_supported_protocols_x2go[];
+extern const gsize
+rda_supported_protocols_x2go_len;
 
 gboolean
 rda_session_is_x2go (void);

--- a/util/rdacheck.c
+++ b/util/rdacheck.c
@@ -26,12 +26,14 @@ Copyright 2019, Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
 #include <glib/gi18n.h>
 
 #include <rda.h>
+#include <rda_protocol.h>
 
 int
 main (int __attribute__((unused)) argc, char __attribute__((unused)) **argv)
 {
 	rda_init();
 	g_message(_("Currently used remote technology: %s"), rda_get_remote_technology_name());
+	g_message(_("Currently used protocol: %s"), rda_get_protocol_name());
 
 	g_message(_("RDA supports the following remote technologies:"));
 
@@ -39,4 +41,13 @@ main (int __attribute__((unused)) argc, char __attribute__((unused)) **argv)
 		gchar* item = tech->data;
 		g_message("    * %s", item);
 	}
+
+	g_message(_("RDA supports the following protocols:"));
+
+	GList *proto = NULL;
+	for(proto = rda_supported_protocols_by_name(); proto; proto = proto->next) {
+		gchar* item = proto->data;
+		g_message("    * %s", item);
+	}
+	g_list_free_full(g_steal_pointer(&proto), free);
 }


### PR DESCRIPTION
So far, librda was able to detect remote technologies, but not the backing protocol used by them.

This is a first implementation of generic backing protocol support.

It currently "knows" the protocols none (local), RDP, NX, KDrive and VNC. RDP is being unconditionally set by Ogon, NX and KDrive are automatically detected for X2Go via the X2Go session ID and VNC will currently not ever be reported, since there's no remote technology known to librda which would be based upon VNC.