### PR TITLE
Fix "distcheck" target.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,12 +19,15 @@ BUILT_SOURCES += $(st_file)
 
 librdaincludedir = $(includedir)/rda
 librdainclude_HEADERS =			\
-	rda_supported_technologies.h	\
 	rda_ogon.h			\
 	rda_protocol.h			\
 	rda_util.h			\
 	rda_x2go.h			\
 	rda.h				\
+	$(NULL)
+
+nodist_librdainclude_HEADERS =		\
+	$(st_file)			\
 	$(NULL)
 
 librda_la_SOURCES =			\
@@ -53,8 +56,10 @@ INTROSPECTION_SCANNER_ARGS = --add-include-path=$(srcdir) --warn-all
 INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir)
 
 if HAVE_INTROSPECTION
-introspection_sources = $(librdainclude_HEADERS)	\
-	$(librda_la_SOURCES)				\
+introspection_sources =			\
+	$(librdainclude_HEADERS)	\
+	$(nodist_librdainclude_HEADERS)	\
+	$(librda_la_SOURCES)		\
 	$(NULL)
 
 rda-1.0.gir: librda.la

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -13,6 +13,7 @@ rdacheck_CFLAGS =			\
 	-Wall -Werror			\
 	$(LIBRDA_CFLAGS)		\
 	-I$(top_srcdir)/src/		\
+	-I../src			\
 	-DBUILD_DIR="\"$(builddir)\""	\
 	$(NULL)
 


### PR DESCRIPTION
This PR fixes the `distcheck` target.

Essentially, it does two things:
  - don't distribute the auto-generated file `src/rda_supported_technologies.h`
  - make sure that, when building `rdacheck`, the object-dir-based `src` directory is added to the include path in order to pick up the auto-generated `src/rda_supported_technologies.h` file in `VPATH`-based builds (e.g., out-of-source builds, which `make distcheck` is using).

This PR is based on top of #6, so keeping it as a draft until the other one is merged.